### PR TITLE
Fix #78 in aem-eclipse-developer-tools

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -37,15 +37,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <instructions>
                         <!-- Import any version of javax.inject, to allow running on multiple versions of AEM -->


### PR DESCRIPTION
According to this [issue](https://github.com/tesla/m2eclipse-tycho/issues/4), m2eclipse plugin doesn't need extra execution step to place the generated manifest under /META-INF/. The configurator of the m2eclipse plugin does not ignore this step which generates illegalArgumentException during the create/import of the AEM project in/to Eclipse.